### PR TITLE
Impulse-based collision handling equations that account for angular velocity

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <tr>
             <td>
                 <input type="button" onclick="debugging=!debugging" value="Toggle debugging" />
+                <input type="button" onclick="paused=!paused" value="Pause simulation" />
             </td>
         </tr>
         <tr>

--- a/main.ts
+++ b/main.ts
@@ -9,7 +9,6 @@ const keyDefs = new Map([
     [32, 'space'],
     [65, 'jump'],
 ]);
-const time_step = 150;
 const canvas_size = 1200;
 const canvas_offset_x = 50;
 const canvas_offset_y = 90;
@@ -19,18 +18,18 @@ const field_width = 20;
 const inner_field_width = field_width - 2;
 const field_height = 30;
 const drawing_scale = 6;
-const eps = 0.00001;
+const eps = 0.0000001;
 let debugging = false;
-//
-// const test = new PhysicalObject();
-// test.velocity = new Vector2D(2, );
+let paused = false;
+const slow_down = 1;
+const time_step = 22 * slow_down;
 
 interface IntersectionResult {
     intersection_exists: boolean;
     intersection_point?: Vector2D;
 }
 
-function is_intersecting(l1: Line, l2: Line): IntersectionResult {
+function is_intersecting(l1: Line, l2: Line): Intersection {
     const l1_constants = get_line_constants(l1);
     const A1 = l1_constants[0];
     const B1 = l1_constants[1];
@@ -44,18 +43,13 @@ function is_intersecting(l1: Line, l2: Line): IntersectionResult {
     const det = A1 * B2 - A2 * B1;
 
     if (Math.abs(det) <= eps) {
-        return {
-            intersection_exists: false,
-        };
+        return new Intersection(l1, l2, false, null);
     }
 
     const x = (B2 * C1 - B1 * C2) / det;
     const y = (A1 * C2 - A2 * C1) / det;
 
-    return {
-        intersection_exists: on_segment(l1, x, y) && on_segment(l2, x, y),
-        intersection_point: new Vector2D(x, y)
-    };
+    return new Intersection(l1, l2, on_segment(l1, x, y) && on_segment(l2, x, y), new Vector2D(x, y));
 }
 
 function on_segment(line: Line, x: number, y: number) {
@@ -65,7 +59,7 @@ function on_segment(line: Line, x: number, y: number) {
     const Y2 = line.endPosition.y;
 
     return Math.min(X1, X2) <= x && x <= Math.max(X1, X2) &&
-        Math.min(Y1, Y2) <= y && y <= Math.max(Y1, Y2);
+           Math.min(Y1, Y2) <= y && y <= Math.max(Y1, Y2);
 }
 
 function get_line_constants(line: Line) {
@@ -101,12 +95,16 @@ $(document).ready(() => {
 
     const ctx = canvas.getContext("2d");
 
-    const $time = Rx.Observable.interval(10)
+    const $time = Rx.Observable.interval(10 * slow_down)
         .timeInterval();
 
     $time.scan((game_set, time_unit) => {
-        return game_set.updated(time_unit.interval);
-    }, new GameSet())
+            if (paused) {
+                return game_set;
+            } else {
+                return game_set.updated(time_step);
+            }
+        }, new GameSet(true))
         .subscribe((game_set: GameSet) => {
             ctx.clearRect(0, 0, canvas_size, canvas_size);
             game_set.draw(ctx);
@@ -115,9 +113,13 @@ $(document).ready(() => {
 
 class Entity {
     public id: number;
+    public name: string;
 
-    constructor() {
+    constructor(initialize: boolean = false) {
         this.id = Math.random();
+        if (initialize) {
+            this.initialize();
+        }
     }
     public copy<T extends Entity>(new_values: {}): T {
         return Object.assign(this.get_default(), this, new_values);
@@ -128,31 +130,7 @@ class Entity {
     public equals(e: Entity) {
         return this.id == e.id;
     }
-    public updated(time_unit: number, _: GameSet): Entity {
-        throw new Error('Unsupported method');
-    }
-    public move(vector: Vector2D): Entity {
-        throw new Error('Unsupported method');
-    }
-    public collide(delta_position: Vector2D, delta_angle: number, other: Entity,
-                   game_set: GameSet): CollisionResult {
-        throw new Error('Unsupported method');
-    }
-    public collideAll(delta_position: Vector2D, delta_angle: number,
-                      game_set: GameSet): GameSet {
-        throw new Error('Unsupported method');
-    }
-    public collide_ground(collision: Collision, game_set: GameSet): CollisionResult {
-        throw new Error('Unsupported method');
-    }
-    public rotate(delta_angle: number): Entity {
-        throw new Error('Unsupported method');
-    }
-    public reverse(): Entity {
-        throw new Error('Unsupported method');
-    }
-    public offset(other: Entity): Entity {
-        throw new Error('Unsupported method');
+    protected initialize() {
     }
 }
 
@@ -214,6 +192,18 @@ class Vector2D extends Entity {
     public subtract(vector: Vector2D) {
         return new Vector2D(this.x - vector.x, this.y - vector.y);
     }
+    public cross(vector: Vector2D) {
+        return this.x * vector.y - this.y * vector.x;
+    }
+    public crossW(w: number) {
+        return new Vector2D(this.y * -w, this.x * w);
+    }
+    public dot(vector: Vector2D) {
+        return this.x * vector.x + this.y * vector.y;
+    }
+    public toString() {
+        return "{x: " + this.x + ", y:" + this.y + "}";
+    }
 }
 class Line extends Entity {
     public startPosition: Vector2D;
@@ -237,49 +227,65 @@ class Line extends Entity {
     public rotate(angle: number): Line {
         return this.copy({ startPosition: this.startPosition.rotate(angle), endPosition: this.endPosition.rotate(angle) });
     }
+    public normal(): Vector2D {
+        return this.startPosition.to(this.endPosition).rotate(Math.PI / 2).normalize();
+    }
 }
-
 interface CollisionResult {
     game_set: Entity;
     collision?: Collision;
     delta_position: Vector2D;
     delta_angle: number;
 }
-
 class PhysicalObject extends Entity {
     public position: Vector2D;
     public velocity: Vector2D;
     public angle: number;
     public angularVelocity: number;
     public mass: number;
+    public moment_of_inertia: number;
+    public center_of_mass: Vector2D;
     public lines: Immutable.List<Line>;
 
-    constructor() {
-        super();
+    constructor(initialize: boolean) {
+        super(initialize);
+    }
+    protected initialize() {
+        this.define_attributes();
+        this.build_lines();
+        
+        const contribution_ratio = 1.0 / (2 * this.lines.size);
+        this.moment_of_inertia = this.mass * this.lines.reduce((acc, line) => acc + contribution_ratio * (Math.pow(line.startPosition.length(), 2) + Math.pow(line.endPosition.length(), 2)), 0);
+        this.center_of_mass = this.lines.reduce((com, line) => com.addVector(line.startPosition.multiply(contribution_ratio)).addVector(line.endPosition.multiply(contribution_ratio)), new Vector2D(0, 0));
+    }
+    protected define_attributes() {
         this.position = new Vector2D(10, 20);
         this.velocity = new Vector2D(2, 0);
         this.angle = 0;
         this.angularVelocity = 0;
         this.mass = 1;
+    }
+    protected build_lines() {
         this.lines = Immutable.List();
     }
-    public updated(time_unit: number, _: GameSet) {
+    public updated(time_unit: number): PhysicalObject {
         const gravityVector = new Vector2D(0, 9.8);
-        const air_drag_vector = this.velocity.multiply(0.3 * time_unit / 1000).reverse();
+        const velocity_air_drag_vector = this.velocity.multiply(0.3 * time_unit / 1000).reverse();
+        const angular_velocity_air_drag = this.angularVelocity * -0.4 * time_unit / 1000;
+
         return this.copy({
             position: this.position.addVector(this.velocity.multiply(time_unit * 1.0 / 1000)),
-            velocity: this.velocity.addVector(gravityVector.multiply(time_unit * 1.0 / 1000)).addVector(air_drag_vector),
-            angle: this.angle + this.angularVelocity
-        });
+            velocity: this.velocity.addVector(gravityVector.multiply(time_unit * 1.0 / 1000)).addVector(velocity_air_drag_vector),
+            angle: this.angle + this.angularVelocity * time_unit * 1.0 / 1000,
+            angularVelocity: this.angularVelocity + angular_velocity_air_drag});
     }
     public draw(ctx: CanvasRenderingContext2D) {
+        ctx.save();
+        
         const self = this;
         this.lines.forEach(line => {
             ctx.save();
             ctx.beginPath();
-            if (line.is_tire) {
-                ctx.strokeStyle = "gray";
-            }
             const toDrawStartPosition = self.position.addVector(line.startPosition.rotate(self.angle));
             const toDrawEndPosition = self.position.addVector(line.endPosition.rotate(self.angle));
             ctx.moveTo(drawing_scale * toDrawStartPosition.x, drawing_scale * toDrawStartPosition.y);
@@ -287,57 +293,65 @@ class PhysicalObject extends Entity {
             ctx.stroke();
 
             ctx.beginPath();
-            ctx.strokeStyle = "black";
-            ctx.arc(drawing_scale * (self.position.x), drawing_scale * (self.position.y), 2, 0, 2 * Math.PI);
-            ctx.stroke();
-
-            ctx.beginPath();
-            ctx.strokeStyle = "green";
-            ctx.moveTo(drawing_scale * (self.position.x), drawing_scale * (self.position.y));
-            ctx.lineTo(drawing_scale * (self.position.x + self.velocity.x), drawing_scale * (self.position.y + self.velocity.y));
-            ctx.stroke();
-
-            ctx.beginPath();
-            ctx.strokeStyle = "orange";
-            ctx.moveTo(drawing_scale * (self.position.x), drawing_scale * (self.position.y));
-            ctx.lineTo(drawing_scale * (self.position.x + 200 * self.angularVelocity), drawing_scale * (self.position.y));
+            var start_to_end_vector = line.startPosition.to(line.endPosition);
+            var mid_point = start_to_end_vector.normalize().multiply(start_to_end_vector.length() / 2);
+            var normal_start_position = self.position.addVector(line.startPosition.addVector(mid_point).rotate(self.angle));
+            var normal_end_position = self.position.addVector(line.startPosition.addVector(mid_point).addVector(line.normal()).rotate(self.angle));
+            ctx.moveTo(drawing_scale * normal_start_position.x, drawing_scale * normal_start_position.y);
+            ctx.lineTo(drawing_scale * normal_end_position.x, drawing_scale * normal_end_position.y);
             ctx.stroke();
             ctx.restore();
         });
+
+        if (this.name != "ground") {
+            var toDrawCenterOfMass = self.position.addVector(self.center_of_mass.rotate(self.angle));
+            ctx.beginPath();
+            ctx.strokeStyle = "black";
+            ctx.arc(drawing_scale * toDrawCenterOfMass.x, drawing_scale * toDrawCenterOfMass.y, 2, 0, 2 * Math.PI);
+            ctx.stroke();
+        }
+
+        ctx.beginPath();
+        ctx.strokeStyle = "green";
+        ctx.moveTo(drawing_scale * (self.position.x), drawing_scale * (self.position.y));
+        ctx.lineTo(drawing_scale * (self.position.x + self.velocity.x), drawing_scale * (self.position.y + self.velocity.y));
+        ctx.stroke();
+
+        ctx.beginPath();
+        ctx.strokeStyle = "orange";
+        ctx.moveTo(drawing_scale * (self.position.x), drawing_scale * (self.position.y));
+        ctx.lineTo(drawing_scale * (self.position.x + 8 * self.angularVelocity), drawing_scale * (self.position.y));
+        ctx.stroke();
+        ctx.restore();
     }
     public calculate_collision(other: PhysicalObject) {
-        let intersection_exists = false;
-        let intersection_result = null
-        let selfLine = null;
-        let otherLine = null;
+        var intersections = Immutable.List<Intersection>();
         const self = this;
         this.lines.forEach(l1 => {
             other.lines.forEach(l2 => {
-                intersection_result = is_intersecting(l1.rotate(self.angle).offset(self.position), l2.rotate(other.angle).offset(other.position));
+                const projected_l1 = l1.rotate(self.angle).offset(self.position);
+                const projected_l2 = l2.rotate(other.angle).offset(other.position);
+                const intersection_result = is_intersecting(projected_l1, projected_l2);
                 if (intersection_result.intersection_exists) {
-                    intersection_exists = true;
-                    selfLine = l1;
-                    otherLine = l2;
+                    intersections = intersections.push(intersection_result);
                 }
-            })
+            });
         });
-
-        if (intersection_exists) {
-            return new Collision(selfLine, otherLine, intersection_result);
-        } else return null;
+    
+        return new Collision(intersections);
     }
     public collideAll(delta_position: Vector2D, delta_angle: number, game_set: GameSet): GameSet {
         const self = this;
         const collidedRec = (delta_position_rec: Vector2D, delta_angle_rec: number,
                              game_set_rec: GameSet, remaining: Immutable.List<number>): GameSet => {
             if (remaining.size == 0) {
-                const updated_self = game_set_rec.contents.get(self.id);
+                const updated_self = game_set_rec.contents.get(self.id) as PhysicalObject;
                 return game_set_rec.replace_element(updated_self.move(delta_position_rec).rotate(delta_angle_rec));
             }
 
             const first_key = remaining.first();
-            const first_object = game_set_rec.contents.get(first_key);
-            const updated_self = game_set_rec.contents.get(self.id);
+            const first_object = game_set_rec.contents.get(first_key) as PhysicalObject;
+            const updated_self = game_set_rec.contents.get(self.id) as PhysicalObject;
 
             const collision_result = updated_self.collide(delta_position_rec, delta_angle_rec, first_object, game_set_rec);
             const new_game_set = collision_result.game_set as GameSet;
@@ -354,45 +368,104 @@ class PhysicalObject extends Entity {
         const advanced_self = this.move(delta_position).rotate(delta_angle);
 
         const collision = advanced_self.calculate_collision(other);
-        if (collision == null)
+        if (!collision.collided())
             return {
                 game_set: game_set.replace_element(this),
                 delta_position: delta_position,
                 delta_angle: delta_angle
             };
 
-        if (collision.otherLine.is_ground) {
-            return this.collide_ground(collision, game_set);
+        // Impulse-based collision handling. Reference: https://www.myphysicslab.com/engine2D/collision-en.html#collision_physics
+        const elasticity = 0.7;
+        const impulse_weight = 1.0 / collision.intersections.size;
+
+        if (other.name == "ground") {
+            const collide_rec = (delta_v_a: Vector2D, delta_w_a: number, remaining_intersections: Immutable.List<Intersection>): any => {
+                if (remaining_intersections.size == 0) return {"d_v_a": delta_v_a, "d_w_a": delta_w_a};
+    
+                const first_intersection = remaining_intersections.first();
+                const intersection_point = first_intersection.intersection_point;
+        
+                const normal = first_intersection.other_line.normal(); 
+                const r_ap = advanced_self.position.addVector(advanced_self.center_of_mass).to(intersection_point);
+
+                const v_a1 = advanced_self.velocity;
+                const w_a1 = advanced_self.angularVelocity;
+
+                var v_ap1 = v_a1.addVector(r_ap.crossW(w_a1));
+
+                var m_a = advanced_self.mass;
+                var i_a = advanced_self.moment_of_inertia;
+
+                var impulse = - impulse_weight * (1 + elasticity) * v_ap1.dot(normal) / (1.0/m_a + Math.pow(r_ap.cross(normal), 2)/i_a);
+
+                var d_v_a = normal.multiply(impulse / m_a);
+                var d_w_a = r_ap.cross(normal.multiply(impulse)) / i_a;
+
+                return collide_rec(delta_v_a.addVector(d_v_a), delta_w_a + d_w_a, remaining_intersections.shift());
+            }
+
+            var delta = collide_rec(new Vector2D(0, 0), 0, collision.intersections);
+
+            return {"game_set": game_set.replace_element(this.copy({velocity: this.velocity.addVector(delta.d_v_a), angularVelocity: this.angularVelocity + delta.d_w_a})),
+                    "delta_position": new Vector2D(0, 0),
+                    "delta_angle": 0};
+        } else {
+            var collide_rec = (delta_v_a: Vector2D, delta_w_a: number, delta_v_b: Vector2D, delta_w_b: number, remaining_intersections: Immutable.List<Intersection>): any => {
+                if (remaining_intersections.size == 0) return {"d_v_a": delta_v_a, "d_w_a": delta_w_a, "d_v_b": delta_v_b, "d_w_b": delta_w_b};
+    
+                var first_intersection = remaining_intersections.first();
+                var intersection_point = first_intersection.intersection_point;
+
+                var normal = first_intersection.self_line.normal();
+
+                var v_a1 = advanced_self.velocity;
+                var v_b1 = other.velocity;
+
+                var r_ap = advanced_self.position.addVector(advanced_self.center_of_mass).to(intersection_point);
+                var r_bp = other.position.addVector(advanced_self.center_of_mass).to(intersection_point);
+
+                var w_a1 = advanced_self.angularVelocity;
+                var w_b1 = other.angularVelocity;
+
+                var v_ap1 = v_a1.addVector(r_ap.crossW(w_a1));
+                var v_bp1 = v_b1.addVector(r_bp.crossW(w_b1));
+
+                var v_ab1 = v_ap1.subtract(v_bp1);
+
+                var m_a = advanced_self.mass;
+                var m_b = other.mass;
+
+                var i_a = advanced_self.moment_of_inertia;
+                var i_b = other.moment_of_inertia;
+
+                var impulse = - impulse_weight * (1 + elasticity) * v_ab1.dot(normal) / (1.0/m_a + 1.0/m_b + Math.pow(r_ap.cross(normal), 2)/i_a + Math.pow(r_bp.cross(normal), 2)/i_b);
+
+                // alert("Self: " + advanced_self.position +
+                    // "\nOther: " + other.position + 
+                    // "\nIntersection: " + intersection_point + 
+                    // "\nImpulse: " + impulse +
+                    // "\nVelocity: " + v_ab1.dot(normal) +
+                    // "\nTerm: " + (1.0/m_a + 1.0/m_b));
+
+                var d_v_a = normal.multiply(impulse / m_a);
+                var d_v_b = normal.multiply(-impulse / m_b);
+
+                var d_w_a = r_ap.cross(normal.multiply(impulse)) / i_a;
+                var d_w_b = -r_bp.cross(normal.multiply(impulse)) / i_b;
+
+                return collide_rec(delta_v_a.addVector(d_v_a), delta_w_a + d_w_a, delta_v_b.addVector(d_v_b), delta_w_b + d_w_b, remaining_intersections.shift());
+            }
+
+            var delta = collide_rec(new Vector2D(0, 0), 0, new Vector2D(0, 0), 0, collision.intersections);
+
+            var updated_self = this.copy({velocity: this.velocity.addVector(delta.d_v_a), angularVelocity: this.angularVelocity + delta.d_w_a});
+            var updated_other = other.copy({velocity: other.velocity.addVector(delta.d_v_b), angularVelocity: other.angularVelocity + delta.d_w_b});
+
+            return {"game_set": game_set.replace_element(updated_self).replace_element(updated_other),
+                    "delta_position": new Vector2D(0, 0),
+                    "delta_angle": 0};
         }
-        else {
-            const directionAngle = advanced_self.position.to(other.position).angle();
-
-            const self_velocity_rotated = advanced_self.velocity.rotate(-directionAngle);
-            const other_velocity_rotated = other.velocity.rotate(-directionAngle);
-
-            const new_self_velocity = (new Vector2D((self_velocity_rotated.x * (this.mass - other.mass) + 2 * other.mass * other_velocity_rotated.x) / (this.mass + other.mass), self_velocity_rotated.y)).rotate(directionAngle);
-            const new_other_velocity = (new Vector2D((other_velocity_rotated.x * (other.mass - this.mass) + 2 * this.mass * self_velocity_rotated.x) / (this.mass + other.mass), other_velocity_rotated.y)).rotate(directionAngle);
-
-            const new_self = this.copy({
-                velocity: new_self_velocity,
-                angularVelocity: 0
-            });
-
-            const new_other = other.copy({
-                velocity: new_other_velocity,
-                angularVelocity: 0
-            });
-
-            return {
-                game_set: game_set.replace_element(new_self).replace_element(new_other),
-                collision: collision,
-                delta_position: new Vector2D(0, 0),
-                delta_angle: 0
-            };
-        }
-    }
-    public collide_ground(collision: Collision, game_set: GameSet): CollisionResult {
-        throw new Error('Unsupported method');
     }
     public move(vector: Vector2D): PhysicalObject {
         return this.copy({ position: this.position.addVector(vector) });
@@ -401,63 +474,70 @@ class PhysicalObject extends Entity {
         return this.copy({ angle: this.angle + delta_angle });
     }
 }
-
-class Collision extends Entity {
-    public selfLine: Line;
-    public otherLine: Line;
-    public intersection_result: IntersectionResult;
-
-    constructor(selfLine: Line, otherLine: Line, intersection_result: IntersectionResult) {
-        super();
-        this.selfLine = selfLine;
-        this.otherLine = otherLine;
-        this.intersection_result = intersection_result;
+class GameElement extends PhysicalObject {
+    constructor(initialize: boolean) {
+        super(initialize);
+    }
+    public update_game_set(time_unit: number, game_set: GameSet): GameSet {
+        throw new Error('Unsupported method');
     }
 }
-
-class Ball extends PhysicalObject {
-    public radius: number;
-    public lines: Immutable.List<Line>;
-
-    constructor() {
+class Intersection extends Entity {
+    public self_line: Line;
+    public other_line: Line;
+    public intersection_exists: boolean;
+    public intersection_point: Vector2D;
+    
+    constructor(sl: Line, ol: Line, intersection_exists: boolean, intersection_point: Vector2D) {
         super();
-        this.position = new Vector2D(60, 70);
-        this.velocity = new Vector2D(10, 0);
-        this.radius = 10;
-        this.mass = 1;
-        this._build_lines();
+        this.self_line = sl;
+        this.other_line = ol;
+        this.intersection_exists = intersection_exists;
+        this.intersection_point = intersection_point;
     }
-    private _build_lines() {
-        this.lines = Immutable.List();
-        const samples = 16;
-        for (let s = 0; s < samples; s++) {
-            const angle1 = s * 2 * Math.PI / samples;
-            const angle2 = (s + 1) * 2 * Math.PI / samples;
+}
+class Collision extends Entity {
+    public intersections: Immutable.List<Intersection>;
 
-            const startPosition = new Vector2D(this.radius * Math.cos(angle1), this.radius * Math.sin(angle1));
-            const endPosition = new Vector2D(this.radius * Math.cos(angle2), this.radius * Math.sin(angle2));
+    constructor(intersections: Immutable.List<Intersection>) {
+        super();
+        this.intersections = intersections;
+    }
+    collided() {
+        return this.intersections.size > 0;
+    }
+}
+class Ball extends GameElement {
+    public radius: number;
+
+    constructor(initialize: boolean) {
+        super(initialize);
+    }
+    protected define_attributes() {
+        super.define_attributes();
+        this.radius = 10;
+        this.position = new Vector2D(60, 20);
+        this.velocity = new Vector2D(10, 0);
+        this.mass = 4;
+        this.name = "ball";
+    }
+    protected build_lines() {
+        super.build_lines();
+        const samples = 24;
+        for (var s = 0; s < samples; s++) {
+            var angle1 = -s * 2 * Math.PI / samples;
+            var angle2 = -(s + 1) * 2 * Math.PI / samples;
+
+            var startPosition = new Vector2D(this.radius * Math.cos(angle1), this.radius * Math.sin(angle1));
+            var endPosition = new Vector2D(this.radius * Math.cos(angle2), this.radius * Math.sin(angle2));
             this.lines = this.lines.push(new Line(startPosition, endPosition));
         }
     }
-    public updated(time_unit: number, game_set: GameSet) {
-        const advanced_ball: Ball = super.updated(time_unit, game_set) as Ball;
+    public update_game_set(time_unit: number, game_set: GameSet): GameSet {
+        const advanced_ball: Ball = super.updated(time_unit) as Ball;
 
         const advanced_ball_original_position: Ball = advanced_ball.copy({ position: this.position, angle: this.angle }) as Ball;
         return advanced_ball_original_position.collideAll(advanced_ball.position.subtract(this.position), advanced_ball.angle - this.angle, game_set);
-    }
-    public collide_ground(collision: Collision, game_set: GameSet) {
-        const elasticity = 0.8;
-        const collided_self = this.copy({
-            velocity: this.velocity.reverseDirection(collision.otherLine.collision_direction).multiply(elasticity),
-            angularVelocity: 0
-        });
-
-        return {
-            game_set: game_set.replace_element(collided_self),
-            collision: collision,
-            delta_position: new Vector2D(0, 0),
-            delta_angle: 0,
-        };
     }
     public draw(ctx: CanvasRenderingContext2D) {
         ctx.save();
@@ -492,29 +572,33 @@ class Ball extends PhysicalObject {
     }
 }
 
-class Car extends PhysicalObject {
+class Car extends GameElement {
     public flying_state: string;
     public jump_state: string;
     public nitro: Vector2D;
     public jumper: Vector2D;
 
-    constructor() {
-        super();
-        this.position = new Vector2D(50, 90);
-        this.mass = 10;
+    constructor(initialize: boolean) {
+        super(initialize);
+    }
+    protected define_attributes() {
+        super.define_attributes();
+        this.position = new Vector2D(60, 65);
+        this.velocity = new Vector2D(0, -10);
+        this.angularVelocity = 0;
+        this.mass = 40;
         this.flying_state = "flying";
         this.jump_state = "station";
-        this._build_lines();
+        this.name = "car";
     }
-    private _build_lines() {
+    protected build_lines() {
+        super.build_lines();
+
         const f = 3;
-        // const points = [[20, 10], [20, 4], [-2, -7], [-20, -10], [-20, 10], [-19, 12], [-11, 12], [-10, 10], [10, 10], [11, 12], [19, 12]];
-        // const tire =    [false,   false,   false,    false,      true,      true,      true,      false,     true,     true,     true];
 
         const points = [[20, 14], [20, 4], [-2, -7], [-20, -10], [-20, 14]];
         const tire = [false, false, false, false, false];
 
-        this.lines = Immutable.List();
         for (let i = 0; i < points.length; i++) {
             const j = (i + 1) % points.length;
             const p1 = points[i];
@@ -525,8 +609,8 @@ class Car extends PhysicalObject {
         this.nitro = new Vector2D(-20 / f, 0);
         this.jumper = new Vector2D(0, 14 / f);
     }
-    public updated(time_unit: number, game_set: GameSet) {
-        const advanced_car_gravity: Car = super.updated(time_unit, game_set) as Car;
+    public update_game_set(time_unit: number, game_set: GameSet): GameSet{
+        const advanced_car_gravity: Car = super.updated(time_unit) as Car;
 
         const jumped_car: Car = key_pressed.get("jump") ?
             (this.jump_state == "station" ?
@@ -539,41 +623,17 @@ class Car extends PhysicalObject {
         const car_jumping = this.jump_state == "station" && jumped_car.jump_state == "jumping";
         const car_flying = this.flying_state == "flying";
 
-        const nitroVector = this.nitro.normalize().multiply(key_pressed.get("up")).rotate(this.angle).reverse().multiply(30);
+        const nitroVector = this.nitro.normalize().multiply(key_pressed.get("up")).rotate(this.angle).reverse().multiply(20);
         const jumpVector = this.jumper.normalize().multiply(car_jumping ? 1 : 0).rotate(this.angle).reverse().multiply(10);
-        const angularForce = (key_pressed.get("left") * -1 + key_pressed.get("right")) * (car_flying ? 1 : 0);
+        const angularForce = (key_pressed.get("left") * -1 + key_pressed.get("right")) * (car_flying ? 4 : 0);
 
         const advanced_car: Car = jumped_car.copy({
             velocity: jumped_car.velocity.addVector(nitroVector.multiply(time_unit * 1.0 / 1000)).addVector(jumpVector),
-            angularVelocity: jumped_car.angularVelocity + angularForce * 0.0006
+            angularVelocity: jumped_car.angularVelocity + angularForce * time_unit * 1.0 / 1000
         });
 
-        const advanced_car_original_position = advanced_car.copy({ position: this.position, angle: this.angle });
+        const advanced_car_original_position = advanced_car.copy<Car>({ position: this.position, angle: this.angle });
         return advanced_car_original_position.collideAll(advanced_car.position.subtract(this.position), advanced_car.angle - this.angle, game_set);
-    }
-    public collide_ground(collision: Collision, game_set: GameSet): CollisionResult {
-        const elasticity = 0.6;
-        const collision_angle = collision.otherLine.collision_direction.angle();
-        let collided_self: Car = null;
-        if (collision.selfLine.is_tire && false) {
-            // collided_self = this.copy({
-            //     velocity: this.velocity.rotate(collision_angle).resetX().rotate(-collision_angle),
-            //     angle: collision_angle + Math.PI / 2,
-            //     flying_state: "on_ground",
-            //     angularVelocity: 0});
-        } else {
-            collided_self = this.copy({
-                velocity: this.velocity.rotate(-collision_angle).multiplyX(-elasticity).rotate(collision_angle),
-                angularVelocity: 0
-            });
-        }
-
-        return {
-            game_set: game_set.replace_element(collided_self),
-            collision: collision,
-            delta_position: new Vector2D(0, 0),
-            delta_angle: 0,
-        };
     }
     public draw(ctx: CanvasRenderingContext2D) {
         const f = 3;
@@ -698,21 +758,28 @@ class Car extends PhysicalObject {
     }
 }
 
-class Ground extends PhysicalObject {
+class Ground extends GameElement {
     public lines: Immutable.List<Line>;
 
-    constructor() {
-        super();
+    constructor(initialize: boolean) {
+        super(initialize);
+    }
+    protected define_attributes() {
+        super.define_attributes();
+        this.name = "ground";
         this.position = new Vector2D(0, 0);
+    }
+    protected build_lines() {
+        super.build_lines()
         this.lines = Immutable.List([
-            new Line(new Vector2D(0, 100), new Vector2D(200, 100), new Vector2D(0, -1), true),
-            new Line(new Vector2D(0, 0), new Vector2D(0, 100), new Vector2D(1, 0), true),
+            new Line(new Vector2D(200, 100), new Vector2D(0, 100), new Vector2D(0, -1), true),
+            new Line(new Vector2D(0, 100), new Vector2D(0, 0), new Vector2D(1, 0), true),
             new Line(new Vector2D(200, 0), new Vector2D(200, 100), new Vector2D(-1, 0), true)]);
     }
     public collisionDirection() {
         return new Vector2D(0, -1);
     }
-    public updated(_: number, game_set: GameSet) {
+    public update_game_set(_: number, game_set: GameSet) {
         return game_set;
     }
 }
@@ -721,11 +788,15 @@ class GameSet extends Entity {
     public contents: Immutable.Map<number, Entity>;
     public ground_id: number;
 
-    constructor() {
-        super();
-        const my_car = new Car();
-        const ground = new Ground();
-        const ball = new Ball();
+    constructor(initialize: boolean) {
+        super(initialize);
+    }
+    protected initialize() {
+        super.initialize();
+
+        const my_car = new Car(true);
+        const ground = new Ground(true);
+        const ball = new Ball(true);
 
         this.contents = Immutable.Map([
             [my_car.id, my_car],
@@ -740,20 +811,16 @@ class GameSet extends Entity {
                 return game_set;
 
             const first_key = remaining.first();
-            const first_object = game_set.contents.get(first_key);
+            const first_object = game_set.contents.get(first_key) as GameElement;
 
-            const new_game_set = first_object.updated(time_unit, game_set) as GameSet;
+            const new_game_set = first_object.update_game_set(time_unit, game_set) as GameSet;
             return updatedRec(new_game_set, remaining.shift());
         }
 
         return updatedRec(this, this.contents.keySeq().filter(o => o != this.ground_id).toList());
-        // return this.copy({my_car: this.my_car.updated(time_unit, this), ball: this.ball.updated(time_unit, this)});
     }
     public draw(ctx: CanvasRenderingContext2D) {
-        this.contents.valueSeq().forEach((o: PhysicalObject) => o.draw(ctx));
-        // this.my_car.draw(ctx);
-        // this.ball.draw(ctx);
-        // this.ground.draw(ctx);
+        this.contents.valueSeq().forEach((o: GameElement) => o.draw(ctx));
     }
     public replace_element(element: Entity): GameSet {
         return this.copy({ "contents": this.contents.set(element.id, element) });


### PR DESCRIPTION
Earlier implemented logic for collisions handling didn't account for angular velocities for colliding bodies (Old method used was the one described here: https://en.wikipedia.org/wiki/Elastic_collision).

The changes here implement impulse-based collision handling that account for the angular velocities of the colliding bodies. Angular velocities get translated to the intersection point to generate an impulse force in the normal direction of the edges. The impulse force also result in new angular velocities for the bodies around their center of mass. Reference: https://www.myphysicslab.com/engine2D/collision-en.html#collision_physics

Noticeable improvements in the simulation:
-  Angular velocity no longer gets reset to zero. Instead, calculations for the new angular velocities of bodies are in place (Check out what happens now when a tilted car falls down to the floor - it wiggles back and forth before settling horizontally on the floor).
- Angular velocity now could result in positional translation (e.x. a rotating car colliding the ball will cause it to be thrown upon impact - this was missing in the earlier simulation).