### PR TITLE
Removing GameSet dependency from PhysicalObject

### DIFF
--- a/src/ball.ts
+++ b/src/ball.ts
@@ -36,14 +36,8 @@ export default class Ball extends GameElement {
     }
   }
 
-  public update_game_set(time_unit: number, game_set: GameSet): GameSet {
-    const advanced_ball: Ball = this._updated_physics(time_unit) as Ball;
-
-    const advanced_ball_original_position: Ball = advanced_ball.copy({
-        position: this.position, angle: this.angle }) as Ball;
-    return advanced_ball_original_position.collideAll(
-        advanced_ball.position.subtract(this.position),
-        advanced_ball.angle - this.angle, game_set);
+  public updated(time_unit: number): GameElement {
+    return this._updated_physics(time_unit) as Ball;
   }
 
   public draw(ctx: CanvasRenderingContext2D, camera_position: Vector2D) {

--- a/src/ball.ts
+++ b/src/ball.ts
@@ -1,10 +1,11 @@
 import Constants from './constants'
-import GameElement from './game_element'
 import GameSet from './game_set'
 import Vector2D from './vector2d'
 import {Line} from './line'
+import PhysicalObject from './physical_object';
+import GameElement from './game_element';
 
-export default class Ball extends GameElement {
+export default class Ball extends PhysicalObject {
   public radius: number;
 
   constructor(initialize: boolean) {

--- a/src/ball.ts
+++ b/src/ball.ts
@@ -37,7 +37,7 @@ export default class Ball extends GameElement {
   }
 
   public update_game_set(time_unit: number, game_set: GameSet): GameSet {
-    const advanced_ball: Ball = super.updated(time_unit) as Ball;
+    const advanced_ball: Ball = this._updated_physics(time_unit) as Ball;
 
     const advanced_ball_original_position: Ball = advanced_ball.copy({
         position: this.position, angle: this.angle }) as Ball;

--- a/src/car.ts
+++ b/src/car.ts
@@ -79,86 +79,114 @@ export default class Car extends GameElement {
     });
   }
 
-  public update_game_set(time_unit: number, game_set: GameSet): GameSet{
-    const self = this;
-    const car_after_flip_x_input: Car = Constants.key_pressed.get("S") ?
+  private _apply_flip_x_input(): Car {
+    const after_flip_x_input: Car = Constants.key_pressed.get("S") ?
         (this.flip_x_state == "idle" ?
-            self.copy({ flip_x_state: "active" }) :
-            self) :
+            this.copy({ flip_x_state: "active" }) :
+            this) :
         (this.flip_x_state == "idle" ?
-            self :
-            self.copy({ flip_x_state: "idle" }));
+            this:
+            this.copy({ flip_x_state: "idle" }));
 
-    const car_flipping_x = self.flip_x_state == "idle" &&
-                                                car_after_flip_x_input.flip_x_state == "active";
-    const car_after_flip_x = car_flipping_x  ? car_after_flip_x_input._mirrorX() :
-        car_after_flip_x_input;
+    const is_flipping_x = this.flip_x_state == "idle" &&
+                           after_flip_x_input.flip_x_state == "active";
+    return is_flipping_x ? after_flip_x_input._mirrorX() : after_flip_x_input;
+  }
 
-    const car_after_flip_y_input: Car = Constants.key_pressed.get("D") ?
+  private _apply_flip_y_input(): Car {
+    const after_flip_y_input: Car = Constants.key_pressed.get("D") ?
         (this.flip_y_state == "idle" ?
-            car_after_flip_x.copy({ flip_y_state: "active" }) :
-            car_after_flip_x) :
+            this.copy({ flip_y_state: "active" }) :
+            this) :
         (this.flip_y_state == "idle" ?
-            car_after_flip_x :
-            car_after_flip_x.copy({ flip_y_state: "idle" }));
+            this :
+            this.copy({ flip_y_state: "idle" }));
 
-    const car_flipping_y = self.flip_y_state == "idle" &&
-                           car_after_flip_y_input.flip_y_state == "active";
-    const car_after_flip_y = car_flipping_y ? car_after_flip_y_input._mirrorY() :
-        car_after_flip_y_input;
+    const is_flipping_y = this.flip_y_state == "idle" &&
+                           after_flip_y_input.flip_y_state == "active";
+    return is_flipping_y ? after_flip_y_input._mirrorY() : after_flip_y_input;
+  }
 
-    const car_after_all_flips = car_after_flip_y;
-
-    const advanced_car_gravity: Car = car_after_all_flips.updated(time_unit) as Car;
-
-    const cat_after_nitro_input: Car = advanced_car_gravity.copy({
+  private _apply_nitro_input(time_unit: number): Car {
+    const after_nitro_input: Car = this.copy({
       nitro_state: Constants.key_pressed.get("up") ? "active" : "idle"
     });
-    const car_after_jump_input: Car = Constants.key_pressed.get("A") ?
+
+    const nitro_strength = 20;
+    const is_nitro_active = after_nitro_input.nitro_state == "active";
+
+    const nitro_vector = this.nitro.normalize()
+        .multiply(is_nitro_active ? 1 : 0).rotate(this.angle).reverse().multiply(nitro_strength);
+
+    return after_nitro_input.copy({
+        velocity: after_nitro_input.velocity.add_vector(nitro_vector.multiply(time_unit * 1.0 / 1000))
+    });
+  }
+
+  private _apply_jump_input(time_unit: number): Car {
+    const after_jump_input: Car = Constants.key_pressed.get("A") ?
         (this.jump_state == "station" ?
-            cat_after_nitro_input.copy({
+            this.copy({
               flying_state: "flying",
               jump_state: "jumping",
               jump_timer: Constants.jump_timer_duration
             }) :
-            cat_after_nitro_input.copy({
-              jump_timer: Math.max(0, cat_after_nitro_input.jump_timer - 1)
+            this.copy({
+              jump_timer: Math.max(0, this.jump_timer - 1)
             })) :
         (this.jump_state == "station" ?
-            cat_after_nitro_input.copy({
-              jump_timer: Math.max(0, cat_after_nitro_input.jump_timer - 1)
+            this.copy({
+              jump_timer: Math.max(0, this.jump_timer - 1)
             }) :
-            cat_after_nitro_input.copy({
+            this.copy({
               jump_state: "station",
-              jump_timer: Math.max(0, cat_after_nitro_input.jump_timer - 1)
+              jump_timer: Math.max(0, this.jump_timer - 1)
             }));
-    const car_after_all_input = car_after_jump_input;
 
-    const car_jumping_index = car_after_all_input.jump_timer;
-    const car_jumping = car_after_all_input.jump_timer > 0;
-    const car_flying = car_after_all_input.flying_state == "flying";
-    const nitro_active = car_after_all_flips.nitro_state == "active";
+    const car_jumping_index = after_jump_input.jump_timer;
+    const car_jumping = after_jump_input.jump_timer > 0;
+    const car_flying = after_jump_input.flying_state == "flying";
 
-    const nitro_vector = car_after_all_flips.nitro.normalize()
-        .multiply(nitro_active ? 1 : 0).rotate(this.angle).reverse().multiply(20);
-    const jump_vector = car_after_all_flips.jumper.normalize()
+    const jump_vector = this.jumper.normalize()
         .multiply(car_jumping ? 1 : 0).rotate(this.angle).reverse().multiply(20);
-    const angular_force = (Constants.key_pressed.get("left") * -1 +
-        Constants.key_pressed.get("right")) * (car_flying ? 4 : 0);
 
-    const advanced_car: Car = car_after_all_input.copy({
-        velocity: car_after_all_input.velocity.add_vector(nitro_vector.multiply(time_unit * 1.0 / 1000))
-            .add_vector(jump_vector.multiply(1.0 / Math.pow(2, Constants.jump_timer_duration - car_jumping_index + 1))),
-        angular_velocity: car_after_all_input.angular_velocity +
-            (angular_force * time_unit * 1.0 / 1000)
+    return after_jump_input.copy({
+        velocity: after_jump_input.velocity.add_vector(jump_vector.multiply(1.0 / Math.pow(2, Constants.jump_timer_duration - car_jumping_index + 1))),
     });
+  }
 
-    const advanced_car_original_position = advanced_car.copy<Car>({
+  private _apply_rotation_input(time_unit: number): Car {
+    const angular_force = (Constants.key_pressed.get("left") * -1 +
+        Constants.key_pressed.get("right"));
+    const rotation_strength = 4;
+
+    return this.copy({
+        angular_velocity: this.angular_velocity + (rotation_strength * angular_force * time_unit * 1.0 / 1000)
+    });
+  }
+
+  // public updated(time_unit: number): Car {
+  // }
+
+  public update_game_set(time_unit: number, game_set: GameSet): GameSet{
+    const start_state = this;
+
+    const pipeline = Immutable.List([
+      { method: this._apply_flip_x_input, parameters: [] },
+      { method: this._apply_flip_y_input, parameters: [] },
+      { method: this._apply_nitro_input, parameters: [time_unit] },
+      { method: this._apply_jump_input, parameters: [time_unit] },
+      { method: this._apply_rotation_input, parameters: [time_unit] },
+      { method: this._updated_physics, parameters: [time_unit] }
+    ]);
+    const final_state = pipeline.reduce((current_state, transformer) => transformer.method.call(current_state, transformer.parameters), start_state);
+
+    const advanced_car_original_position = final_state.copy<Car>({
       position: this.position,
       angle: this.angle
     });
     return advanced_car_original_position.collideAll(
-        advanced_car.position.subtract(this.position), advanced_car.angle - this.angle, game_set);
+        final_state.position.subtract(this.position), final_state.angle - this.angle, game_set);
   }
 
   public draw(ctx: CanvasRenderingContext2D, camera_position: Vector2D) {

--- a/src/car.ts
+++ b/src/car.ts
@@ -165,10 +165,7 @@ export default class Car extends GameElement {
     });
   }
 
-  // public updated(time_unit: number): Car {
-  // }
-
-  public update_game_set(time_unit: number, game_set: GameSet): GameSet{
+  public updated(time_unit: number): GameElement {
     const start_state = this;
 
     const pipeline = Immutable.List([
@@ -179,14 +176,9 @@ export default class Car extends GameElement {
       { method: this._apply_rotation_input, parameters: [time_unit] },
       { method: this._updated_physics, parameters: [time_unit] }
     ]);
-    const final_state = pipeline.reduce((current_state, transformer) => transformer.method.call(current_state, transformer.parameters), start_state);
 
-    const advanced_car_original_position = final_state.copy<Car>({
-      position: this.position,
-      angle: this.angle
-    });
-    return advanced_car_original_position.collideAll(
-        final_state.position.subtract(this.position), final_state.angle - this.angle, game_set);
+    const final_state = pipeline.reduce((current_state, transformer) => transformer.method.call(current_state, transformer.parameters), start_state);
+    return final_state;
   }
 
   public draw(ctx: CanvasRenderingContext2D, camera_position: Vector2D) {

--- a/src/car.ts
+++ b/src/car.ts
@@ -1,10 +1,11 @@
 import Constants from './constants'
-import GameElement from './game_element'
 import GameSet from './game_set'
 import {Line} from './line'
 import Vector2D from './vector2d'
+import PhysicalObject from './physical_object';
+import GameElement from './game_element';
 
-export default class Car extends GameElement {
+export default class Car extends PhysicalObject {
   public flying_state: string;
   public jump_state: string;
   public jump_timer: number;

--- a/src/game_element.ts
+++ b/src/game_element.ts
@@ -1,7 +1,7 @@
-import PhysicalObject from './physical_object'
 import GameSet from './game_set'
+import Entity from './entity';
 
-export default class GameElement extends PhysicalObject {
+export default class GameElement extends Entity {
   constructor(initialize: boolean) {
     super(initialize);
   }

--- a/src/game_element.ts
+++ b/src/game_element.ts
@@ -6,7 +6,7 @@ export default class GameElement extends PhysicalObject {
     super(initialize);
   }
 
-  public update_game_set(time_unit: number, game_set: GameSet): GameSet {
+  public updated(time_unit: number): GameElement {
     throw new Error('Unsupported method');
   }
 }

--- a/src/game_set.ts
+++ b/src/game_set.ts
@@ -5,6 +5,7 @@ import Entity from './entity'
 import GameElement from './game_element'
 import Ground from './ground'
 import PhysicalObject from './physical_object'
+import Vector2D from './vector2d';
 
 export default class GameSet extends Entity {
   public contents: Immutable.Map<number, Entity>;
@@ -40,12 +41,56 @@ export default class GameSet extends Entity {
             .toList();
 
     return all_objects_except_ground.reduce(
-      (current_game_set, object) => object.update_game_set(time_unit, current_game_set)
+      (current_game_set, object_id) => current_game_set._updated_per_object(time_unit, current_game_set.contents.get(object_id) as GameElement),
+      this as GameSet
     ); 
   }
 
-  private _updated_per_object(time_unit: number, object: GameElement) {
+  private _updated_per_object(time_unit: number, object: GameElement): GameSet {
+    const next_state = object.updated(time_unit);
+    const next_state_resetted_translation = next_state.copy({ position: object.position, angle: object.angle });
 
+    const delta_position = next_state.position.subtract(object.position);
+    const delta_angle = next_state.angle - object.angle;
+
+    class DeltaState {
+      public position: Vector2D;
+      public angle: number;
+      public game_set: GameSet;
+      constructor(position: Vector2D, angle: number, game_set: GameSet) {
+        this.position = position;
+        this.angle = angle;
+        this.game_set = game_set;
+      }
+    };
+
+    const all_objects_except_me = this.get_objects_except(object).map(e => e.id);
+
+    const final_delta = all_objects_except_me.reduce(
+      (delta, to_collide) => {
+        const updated_self = delta.game_set.contents.get(object.id) as PhysicalObject;
+        const updated_to_collide = delta.game_set.contents.get(to_collide) as PhysicalObject;
+        
+        const collision_result = updated_self.collide(
+          delta.position,
+          delta.angle,
+          updated_to_collide,
+          delta.game_set);
+
+        const new_game_set = collision_result.game_set as GameSet;
+        const new_delta_position = collision_result.delta_position;
+        const new_delta_angle = collision_result.delta_angle;
+
+        return new DeltaState(new_delta_position, new_delta_angle, new_game_set);
+      },
+      new DeltaState(delta_position, delta_angle, this.replace_element(next_state_resetted_translation)));
+    
+      const updated_self = final_delta.game_set.contents.get(object.id) as PhysicalObject;
+      const updated_self_with_delta = updated_self.move(final_delta.position).rotate(final_delta.angle);
+      const must_reset = final_delta.game_set.get_objects_except(object).some(other =>
+          updated_self_with_delta.calculate_collision(other as PhysicalObject).collided());
+      
+      return must_reset ? final_delta.game_set : final_delta.game_set.replace_element(updated_self_with_delta);
   }
 
   public draw(ctx: CanvasRenderingContext2D) {

--- a/src/game_set.ts
+++ b/src/game_set.ts
@@ -6,6 +6,9 @@ import GameElement from './game_element'
 import Ground from './ground'
 import PhysicalObject from './physical_object'
 import Vector2D from './vector2d';
+import {Collision, CollisionResult} from './collision'
+import {Intersection, Line} from './line'
+import Constants from './constants'
 
 export default class GameSet extends GameElement {
   public contents: Immutable.Map<number, PhysicalObject>;
@@ -34,11 +37,9 @@ export default class GameSet extends GameElement {
 
   public updated(time_unit: number) {
     const all_objects_except_ground = 
-        this.contents
-            .entrySeq()
-            .filter(([k, v]) => !v.is_ground)
-            .map(([k, v]) => k)
-            .toList();
+      this.filter_contents(o => !o.is_ground)
+        .map(o => o.id)
+        .toList();
 
     return all_objects_except_ground.reduce(
       (current_game_set, object_id) => current_game_set._updated_per_object(time_unit, current_game_set.contents.get(object_id)),
@@ -48,7 +49,10 @@ export default class GameSet extends GameElement {
 
   private _updated_per_object(time_unit: number, object: PhysicalObject): GameSet {
     const next_state = object.updated(time_unit) as PhysicalObject;
-    const next_state_resetted_translation = next_state.copy<PhysicalObject>({ position: object.position, angle: object.angle });
+    const next_state_resetted_translation = next_state.copy<PhysicalObject>({
+      position: object.position,
+      angle: object.angle
+    });
 
     const delta_position = next_state.position.subtract(object.position);
     const delta_angle = next_state.angle - object.angle;
@@ -64,17 +68,18 @@ export default class GameSet extends GameElement {
       }
     };
 
-    const all_objects_except_me = this.get_objects_except(object).map(e => e.id);
+    const all_objects_except_me = this.filter_contents(o => o.id != object.id).map(e => e.id);
 
     const final_delta = all_objects_except_me.reduce(
       (delta, to_collide) => {
         const updated_self = delta.game_set.contents.get(object.id) as PhysicalObject;
         const updated_to_collide = delta.game_set.contents.get(to_collide) as PhysicalObject;
         
-        const collision_result = updated_self.collide(
+        const collision_result = this._collide(
+          updated_self,
+          updated_to_collide,
           delta.position,
           delta.angle,
-          updated_to_collide,
           delta.game_set);
 
         const new_game_set = collision_result.game_set as GameSet;
@@ -87,10 +92,168 @@ export default class GameSet extends GameElement {
     
       const updated_self = final_delta.game_set.contents.get(object.id);
       const updated_self_with_delta = updated_self.move(final_delta.position).rotate(final_delta.angle);
-      const must_reset = final_delta.game_set.get_objects_except(object).some(other =>
+      const must_reset = final_delta.game_set.filter_contents(o => o.id != object.id).some(other =>
           updated_self_with_delta.calculate_collision(other).collided());
       
       return must_reset ? final_delta.game_set : final_delta.game_set.replace_element(updated_self_with_delta);
+  }
+
+  public _collide(o_a: PhysicalObject, o_b: PhysicalObject, delta_position: Vector2D, delta_angle: number, game_set: GameSet): CollisionResult {
+    const advanced_self = o_a.move(delta_position).rotate(delta_angle);
+
+    const collision = advanced_self.calculate_collision(o_b);
+    if (!collision.collided()) {
+      return {
+        game_set: game_set,
+        delta_position: delta_position,
+        delta_angle: delta_angle
+      };
+    }
+
+    // Impulse-based collision handling.
+    // Reference: https://www.myphysicslab.com/engine2D/collision-en.html#collision_physics
+    const impulse_weight = 1.0 / collision.intersections.size;
+
+    if (o_b.is_ground) {
+      const collide_rec = (delta_v_a: Vector2D, delta_w_a: number, delta_p: Vector2D,
+                           remaining_intersections: Immutable.List<Intersection>): any => {
+        if (remaining_intersections.size == 0) {
+          return {
+            d_v_a: delta_v_a,
+            d_w_a: delta_w_a,
+            d_p: delta_p,
+          };
+        }
+
+        const intersection = remaining_intersections.first();
+        const intersection_point = intersection.intersection_point;
+
+        const elasticity =
+            (intersection.self_line.elasticity + intersection.other_line.elasticity) / 2;
+    
+        const normal = intersection.other_line.normal(); 
+        const r_ap = advanced_self.position.add_vector(advanced_self.center_of_mass)
+                                           .to(intersection_point);
+
+        const v_a1 = advanced_self.velocity;
+        const w_a1 = advanced_self.angular_velocity;
+
+        const v_ap1 = v_a1.add_vector(r_ap.crossW(w_a1));
+
+        const m_a = advanced_self.mass;
+        const i_a = advanced_self.moment_of_inertia;
+
+        const impulse = - impulse_weight * (1 + elasticity) * v_ap1.dot(normal) /
+            (1.0/m_a + Math.pow(r_ap.cross(normal), 2)/i_a);
+
+        const d_v_a = normal.multiply(impulse / m_a);
+        if (Constants.debugging) {
+          console.log(v_a1.toString() + ": " + impulse_weight + " w " + d_v_a.toString());
+        }
+        const d_w_a = r_ap.cross(normal.multiply(impulse)) / i_a;
+
+        const new_delta_p = delta_p.rotate(-normal.angle()).resetX().rotate(normal.angle());
+
+        return collide_rec(delta_v_a.add_vector(d_v_a), delta_w_a + d_w_a, new_delta_p,
+                           remaining_intersections.shift());
+      }
+
+      const delta = collide_rec(Vector2D.empty, 0, delta_position, collision.intersections);
+      const still_colliding = o_a.move(delta.d_p).calculate_collision(o_b).collided();
+
+      return {
+        game_set: game_set.replace_element(o_a.copy({
+            velocity: o_a.velocity.add_vector(delta.d_v_a),
+            angular_velocity: o_a.angular_velocity + delta.d_w_a
+        })),
+        delta_position: still_colliding ? Vector2D.empty : delta.d_p,
+        delta_angle: 0
+      };
+    } else {
+      const collide_rec = (delta_v_a: Vector2D, delta_w_a: number, delta_v_b: Vector2D,
+                           delta_w_b: number, delta_p: Vector2D,
+                           remaining_intersections: Immutable.List<Intersection>): any => {
+        if (remaining_intersections.size == 0) {
+          return {
+            d_v_a: delta_v_a,
+            d_w_a: delta_w_a,
+            d_v_b: delta_v_b,
+            d_w_b: delta_w_b,
+            d_p: delta_p
+          };
+        }
+
+        const intersection = remaining_intersections.first();
+        const intersection_point = intersection.intersection_point;
+
+        const elasticity =
+            (intersection.self_line.elasticity + intersection.other_line.elasticity) / 2;
+
+        const normal = intersection.self_line.normal();
+
+        const v_a1 = advanced_self.velocity;
+        const v_b1 = o_b.velocity;
+
+        const r_ap = advanced_self.position.add_vector(advanced_self.center_of_mass)
+                                           .to(intersection_point);
+        const r_bp = o_b.position.add_vector(advanced_self.center_of_mass)
+                                   .to(intersection_point);
+
+        const w_a1 = advanced_self.angular_velocity;
+        const w_b1 = o_b.angular_velocity;
+
+        const v_ap1 = v_a1.add_vector(r_ap.crossW(w_a1));
+        const v_bp1 = v_b1.add_vector(r_bp.crossW(w_b1));
+
+        const v_ab1 = v_ap1.subtract(v_bp1);
+
+        const m_a = advanced_self.mass;
+        const m_b = o_b.mass;
+
+        const i_a = advanced_self.moment_of_inertia;
+        const i_b = o_b.moment_of_inertia;
+
+        const impulse = - impulse_weight * (1 + elasticity) * v_ab1.dot(normal) /
+            (1.0/m_a + 1.0/m_b + Math.pow(r_ap.cross(normal), 2)/i_a +
+            Math.pow(r_bp.cross(normal), 2)/i_b);
+
+        // alert("Self: " + advanced_self.position +
+            // "\no_b: " + o_b.position + 
+            // "\nIntersection: " + intersection_point + 
+            // "\nImpulse: " + impulse +
+            // "\nVelocity: " + v_ab1.dot(normal) +
+            // "\nTerm: " + (1.0/m_a + 1.0/m_b));
+
+        const d_v_a = normal.multiply(impulse / m_a);
+        const d_v_b = normal.multiply(-impulse / m_b);
+
+        const d_w_a = r_ap.cross(normal.multiply(impulse)) / i_a;
+        const d_w_b = -r_bp.cross(normal.multiply(impulse)) / i_b;
+
+        const new_delta_p = delta_p.rotate(-normal.angle()).resetX().rotate(normal.angle());
+
+        return collide_rec(delta_v_a.add_vector(d_v_a), delta_w_a + d_w_a,
+                           delta_v_b.add_vector(d_v_b), delta_w_b + d_w_b, new_delta_p,
+                           remaining_intersections.shift());
+      }
+
+      const delta = collide_rec(Vector2D.empty, 0, Vector2D.empty, 0, delta_position,
+                                collision.intersections);
+
+      const updated_self = o_a.copy<PhysicalObject>({
+          velocity: o_a.velocity.add_vector(delta.d_v_a),
+          angular_velocity: o_a.angular_velocity + delta.d_w_a
+      });
+      const updated_other = o_b.copy<PhysicalObject>({
+          velocity: o_b.velocity.add_vector(delta.d_v_b),
+          angular_velocity: o_b.angular_velocity + delta.d_w_b
+      });
+      const still_colliding = o_a.move(delta.d_p).calculate_collision(o_b).collided();
+
+      return {"game_set": game_set.replace_element(updated_self).replace_element(updated_other),
+              "delta_position": still_colliding ? Vector2D.empty : delta.d_p,
+              "delta_angle": 0};
+    }
   }
 
   public draw(ctx: CanvasRenderingContext2D) {
@@ -106,10 +269,10 @@ export default class GameSet extends GameElement {
       return this.copy({ contents: this.contents.set(element.id, element) });
   }
 
-  public get_objects_except(element: PhysicalObject): Immutable.List<PhysicalObject> {
+  public filter_contents(predicate: (_: PhysicalObject) => boolean): Immutable.List<PhysicalObject> {
       return this.contents
         .entrySeq()
-        .filter(([k, v]) => k != element.id)
+        .filter(([k, v]) => predicate(v))
         .map(([k, v]) => v)
         .toList();
   } 

--- a/src/game_set.ts
+++ b/src/game_set.ts
@@ -32,34 +32,40 @@ export default class GameSet extends Entity {
   }
 
   public updated(time_unit: number) {
-    const updatedRec = (game_set: GameSet, remaining: Immutable.List<number>): GameSet => {
-      if (remaining.size == 0)
-          return game_set;
+    const all_objects_except_ground = 
+        this.contents
+            .entrySeq()
+            .filter(([k, v]) => !v.is_ground)
+            .map(([k, v]) => k)
+            .toList();
 
-      const first_key = remaining.first();
-      const first_object = game_set.contents.get(first_key) as GameElement;
-
-      const new_game_set = first_object.update_game_set(time_unit, game_set) as GameSet;
-      return updatedRec(new_game_set, remaining.shift());
-    }
-
-    const updated_game_set = updatedRec(this,
-        this.contents.entrySeq().filter(([k, v]) => !v.is_ground).map(([k, v]) => k).toList());
-
-    return updated_game_set;
+    return all_objects_except_ground.reduce(
+      (current_game_set, object) => object.update_game_set(time_unit, current_game_set)
+    ); 
   }
+
+  private _updated_per_object(time_unit: number, object: GameElement) {
+
+  }
+
   public draw(ctx: CanvasRenderingContext2D) {
       const self = this;
-      this.contents.valueSeq().forEach((o: GameElement) =>
-          o.draw(ctx, self.camera.get_coordinates(self)));
+      this.contents
+        .valueSeq()
+        .forEach((o: GameElement) => o.draw(ctx, self.camera.get_coordinates(self)));
   }
+
   public replace_element(element: Entity): GameSet {
-      const physical = element as PhysicalObject;
+    //   const physical = element as PhysicalObject;
       // assert_not(physical.lines.some(line => {let d = line.rotate(physical.angle).offset(physical.position); return d.start_position.y > 100 || d.end_position.y > 100;}), "object overlap bottom ground");
       return this.copy({ contents: this.contents.set(element.id, element) });
   }
+
   public get_objects_except(element: Entity): Immutable.List<Entity> {
-      return this.contents.entrySeq().filter(([k, v]) =>
-          k != element.id).map(([k, v]) => v).toList();
+      return this.contents
+        .entrySeq()
+        .filter(([k, v]) => k != element.id)
+        .map(([k, v]) => v)
+        .toList();
   } 
 }

--- a/src/ground.ts
+++ b/src/ground.ts
@@ -1,10 +1,10 @@
 import Constants from './constants'
-import GameElement from './game_element'
 import GameSet from './game_set'
 import Vector2D from './vector2d'
 import {Line} from './line'
+import PhysicalObject from './physical_object';
 
-export default class Ground extends GameElement {
+export default class Ground extends PhysicalObject {
   public outer_lines: Immutable.List<Line>;
   public points: Immutable.List<Array<number>>;
   public outer_points: Immutable.List<Array<number>>;

--- a/src/physical_object.ts
+++ b/src/physical_object.ts
@@ -170,20 +170,21 @@ export default class PhysicalObject extends GameElement {
   }
 
   public calculate_collision(other: PhysicalObject) {
-    var intersections = Immutable.List<Intersection>();
     const self = this;
-    this.lines.forEach(l1 => {
+    var intersection_results = this.lines
+      .flatMap(l1 => {
         const projected_l1 = l1.rotate(self.angle).offset(self.position);
-        other.lines.forEach(l2 => {
+        return other.lines
+          .map(l2 => {
             const projected_l2 = l2.rotate(other.angle).offset(other.position);
-            const intersection_result = projected_l1.is_intersecting(projected_l2);
-            if (intersection_result.intersection_exists) {
-                intersections = intersections.push(intersection_result);
-            }
-        });
-    });
+            return projected_l1.is_intersecting(projected_l2);
+          });
+      });
 
-    return new Collision(intersections);
+    return new Collision(
+      intersection_results
+        .filter(x => x.intersection_exists)
+        .toList());
   }
 
   public collide(delta_position: Vector2D, delta_angle: number, other: PhysicalObject,

--- a/src/physical_object.ts
+++ b/src/physical_object.ts
@@ -5,10 +5,11 @@ import Entity from './entity'
 import GameSet from './game_set'
 import Vector2D from './vector2d'
 import {Intersection, Line} from './line'
+import GameElement from './game_element';
 
 const gravity_vector = new Vector2D(0, 9.8);
 
-export default class PhysicalObject extends Entity {
+export default class PhysicalObject extends GameElement {
   public position: Vector2D;
   public velocity: Vector2D;
   public angle: number;
@@ -332,11 +333,11 @@ export default class PhysicalObject extends Entity {
       const delta = collide_rec(Vector2D.empty, 0, Vector2D.empty, 0, delta_position,
                                 collision.intersections);
 
-      const updated_self = this.copy({
+      const updated_self = this.copy<PhysicalObject>({
           velocity: this.velocity.add_vector(delta.d_v_a),
           angular_velocity: this.angular_velocity + delta.d_w_a
       });
-      const updated_other = other.copy({
+      const updated_other = other.copy<PhysicalObject>({
           velocity: other.velocity.add_vector(delta.d_v_b),
           angular_velocity: other.angular_velocity + delta.d_w_b
       });

--- a/src/physical_object.ts
+++ b/src/physical_object.ts
@@ -185,37 +185,6 @@ export default class PhysicalObject extends Entity {
     return new Collision(intersections);
   }
 
-  public collideAll(delta_position: Vector2D, delta_angle: number, game_set: GameSet): GameSet {
-    const self = this;
-    const collided_all_rec = (delta_position_rec: Vector2D, delta_angle_rec: number,
-                         game_set_rec: GameSet, remaining: Immutable.List<number>): GameSet => {
-      if (remaining.size == 0) {
-        const updated_self = game_set_rec.contents.get(self.id) as PhysicalObject;
-        const updated_self_with_delta =
-            updated_self.move(delta_position_rec).rotate(delta_angle_rec);
-        const must_reset = game_set_rec.get_objects_except(self).some(other =>
-            updated_self_with_delta.calculate_collision(other as PhysicalObject).collided());
-        
-        return must_reset ? game_set_rec : game_set_rec.replace_element(updated_self_with_delta);
-      }
-
-      const first_key = remaining.first();
-      const first_object = game_set_rec.contents.get(first_key) as PhysicalObject;
-      const updated_self = game_set_rec.contents.get(self.id) as PhysicalObject;
-
-      const collision_result = updated_self.collide(delta_position_rec, delta_angle_rec,
-                                                    first_object, game_set_rec);
-      const new_game_set = collision_result.game_set as GameSet;
-      const new_delta_position = collision_result.delta_position;
-      const new_delta_angle = collision_result.delta_angle;
-
-      return collided_all_rec(new_delta_position, new_delta_angle, new_game_set, remaining.shift());
-    }
-
-    return collided_all_rec(delta_position, delta_angle, game_set.replace_element(this),
-                            game_set.contents.keySeq().filter(o => o != this.id).toList());
-  }
-
   public collide(delta_position: Vector2D, delta_angle: number, other: PhysicalObject,
                  game_set: GameSet): CollisionResult {
     const advanced_self = this.move(delta_position).rotate(delta_angle);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,12 @@
+import Entity from "./entity";
+import PipelineTransformer from "./pipeline_transformer";
+
+export default class Pipeline<T> {
+    public transformers: Immutable.List<PipelineTransformer<T>>;
+    constructor(transformers: Immutable.List<PipelineTransformer<T>>) {
+        this.transformers = transformers;
+    }
+    public execute(initia_state: T): T {
+        return this.transformers.reduce((current_state, transformer) => transformer.method.call(current_state, transformer.parameters), initia_state);
+    }
+}

--- a/src/pipeline_transformer.ts
+++ b/src/pipeline_transformer.ts
@@ -1,0 +1,10 @@
+import Entity from "./entity";
+
+export default class PipelineTransformer<T> {
+    public method: (..._: any[]) => T;
+    public parameters: any[];
+    constructor(method: (..._: any[]) => T, parameters: any[]) {
+        this.method = method;
+        this.parameters = parameters;
+    }
+}


### PR DESCRIPTION
The essential part of this PR is removing the `GameSet` dependency from `PhysicalObject`. Other minor refactoring work here and there:

- Break `Car.update()` logic into smaller pieces that are assembled in a pipeline. Future note, need to implement a better representation of the state (e.x. Jump state transitions are coded in the `Car` class. This is better handled by encapsulating that implementation in `JumpState` class that implements the different transitions for different inputs.
- Swap `GameElement` and `PhysicalObject` inheritance order. Now `PhysicalObject` inherits `GameElement` and not the other way around. Not all game elements are necessarily `PhysicalObject`s.
- Break some long lines.
- use `Reduce()` instead of inline recursive methods (e.x. `GameSet.updated_per_object()` vs `GameSet._updated()` logic). 

  